### PR TITLE
Update for depreciations, Compat entries for project, Test Environment

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -86,6 +86,7 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -148,7 +149,7 @@ uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 version = "0.10.3"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PositiveFactorizations]]

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,16 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
+[compat]
+julia = "1"
+BusinessDays = "^0.9"
+ForwardDiff = "^0.10"
+Optim = "^0.17"
+Reexport = "^0.2"
+SpecialFunctions = "^0.7"
+StatsBase = "^0.29"
+StatsFuns = "^0.8"
+
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -23,6 +33,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["CSV", "DataFrames", "Test"]
-
-[compat]
-julia = "1"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -510,7 +510,7 @@ using Miletus, BusinessDays
 using Miletus.TermStructure
 using Miletus.DayCounts
 
-import Miletus: Both, Receive, Contract, When, AtObs, value
+import Miletus: Both, Receive, Contract, When, At, value
 import Miletus: YieldModel
 import BusinessDays: USGovernmentBond
 import Base.Dates: today, days, Day, Year
@@ -519,7 +519,7 @@ import Base.Dates: today, days, Day, Year
 First let's show an example of the creation of a zero coupon bond.  For this type of bond a payment of the par amount occurs only on the maturity date.
 
 ```@example couponbond
-zcb = When(AtObs(today()+Day(360)), Receive(100USD))
+zcb = When(At(today()+Day(360)), Receive(100USD))
 ```
 
 Next let's define a function for our coupon bearing bond.  The definition of multiple coupon payments and the final par payment involves a nested set of `Both` types, with each individual payment constructed from a `When` of an date observation and a payment contract.
@@ -527,10 +527,10 @@ Next let's define a function for our coupon bearing bond.  The definition of mul
 ```@example couponbond
 function couponbond(par,coupon,periods::Int,start::Date,expiry::Date)
     duration = expiry - start
-    bond = When(AtObs(expiry), Receive(par))
+    bond = When(At(expiry), Receive(par))
     for p = periods-1:-1:1
         coupondate = start + duration*p/periods
-        bond = Both(bond,When(AtObs(coupondate), Receive(coupon)))
+        bond = Both(bond,When(At(coupondate), Receive(coupon)))
     end
     return bond
 end

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -143,9 +143,9 @@ Built-in primitive `Observable` types include the following:
 
 Built-in derived observable types include the following:
 
-* `AtObs(t::Date) <: Observable{Bool}`
+* `At(t::Date) <: Observable{Bool}`
 
-    * `AtObs(t::Date) = LiftObs(==,DateObs(),ConstObs(t))`
+    * `At(t::Date) = LiftObs(==,DateObs(),ConstObs(t))`
     * An observable that is `true` when the date is `t`
     * This type of observable is used as part of the construction of the derived contract primitives `ZCB`, `WhenAt`, `Forward`, and `European`
 
@@ -183,16 +183,16 @@ The expression `At(Date("2016-12-25"))` creates a new `LiftObs` observable objec
 using Miletus # hide
 import Miletus: LiftObs, DateObs, ConstObs # hide
 
-typealias AtObs LiftObs{typeof(==),Tuple{DateObs,ConstObs{Date}},Bool}
+typealias At LiftObs{typeof(==),Tuple{DateObs,ConstObs{Date}},Bool}
 
-AtObs(t::Date) = LiftObs(==,DateObs(),ConstObs(t))
+At(t::Date) = LiftObs(==,DateObs(),ConstObs(t))
 
-typealias At AtObs
+typealias At At
 
 nothing # hide
 ```
 
-The arguments to `LiftObs` in the definition of `AtObs` include:
+The arguments to `LiftObs` in the definition of `At` include:
 
 * The `==` function that will be applied to two observable values on date quantities
 * A `DateObs` object that acts as a reference observable quantity for the "Current Date" when valuing a model
@@ -212,7 +212,7 @@ With use of the `When` primitive `Contract`, the combination of our defined `Rec
 
 The concept of optionality provides a contract acquirer with a choice on whether to exercise particular rights embedded in that contract.  The most basic `Contract` primitives representing optionality in Miletus are the `Either` and `Cond` primitives described previously.
 
-Adjusting the zero coupon bond example above to incorporate the `Either`, `Both` and `AtObs` `Contract` and `Observable` primitives allow for implementing a European Call option as repeated below.
+Adjusting the zero coupon bond example above to incorporate the `Either`, `Both` and `At` `Contract` and `Observable` primitives allow for implementing a European Call option as repeated below.
 
 ```@example motivating
 x = When(At(Date("2016-12-25")), Either(Both(SingleStock(), Pay(100USD)), Zero()))
@@ -247,11 +247,11 @@ By combining these contract primitives, a set of `typealias` quantities are defi
 
     * Sell a contract `c` for an amount of a particular real valued object or currency
 
-* `ZCB(date::Date, x::Union{Real,CurrencyQuantity}) = When(AtObs(date), Receive(x))`
+* `ZCB(date::Date, x::Union{Real,CurrencyQuantity}) = When(At(date), Receive(x))`
 
     * A "Zero Coupon Bond" that provides for obtaining a particular amount of a real valued object or currency on a particular maturity `date`
 
-* `WhenAt(date::Date, c::Contract) = When(AtObs(date), c)`
+* `WhenAt(date::Date, c::Contract) = When(At(date), c)`
 
     * Activate the contract `c` on the particular maturity `date`
 

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,0 +1,215 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BusinessDays]]
+deps = ["Dates"]
+git-tree-sha1 = "ad6ee7cc6fb2d80522272458cd1b65917965eaec"
+uuid = "4f18b42c-503e-5345-9536-bb0f25fc7038"
+version = "0.9.9"
+
+[[CSV]]
+deps = ["CategoricalArrays", "DataFrames", "Dates", "FilePathsBase", "Mmap", "Parsers", "PooledArrays", "Tables", "Unicode", "WeakRefStrings"]
+git-tree-sha1 = "52a8e60c7822f53d57e4403b7f2811e7e1bdd32b"
+uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+version = "0.6.2"
+
+[[CategoricalArrays]]
+deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "Unicode"]
+git-tree-sha1 = "a6c17353ee38ddab30e73dcfaa1107752de724ec"
+uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+version = "0.8.1"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "48c20c43e157c6eab6cf88326504ec042b05e456"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.10.0"
+
+[[DataAPI]]
+git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.3.0"
+
+[[DataFrames]]
+deps = ["CategoricalArrays", "Compat", "DataAPI", "Future", "InvertedIndices", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
+git-tree-sha1 = "1b4d832288e2d919eeaccdf1d9af7a8a57d773d6"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+version = "0.21.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "7d7578b00789cf16c5f68fad71868e773edd58a2"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.17.16"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FilePathsBase]]
+deps = ["Dates", "LinearAlgebra", "Printf", "Test", "UUIDs"]
+git-tree-sha1 = "923fd3b942a11712435682eaa95cc8518c428b2c"
+uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
+version = "0.8.0"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[InvertedIndices]]
+deps = ["Test"]
+git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
+uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+version = "1.0.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.3"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+git-tree-sha1 = "12ce190210d278e12644bcadf5b21cbdcf225cd3"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.2.0"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "f0abb338b4d00306500056a3fd44c221b8473ef2"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.4"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PooledArrays]]
+deps = ["DataAPI"]
+git-tree-sha1 = "b1333d4eced1826e15adbdf01a4ecaccca9d353c"
+uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+version = "0.5.3"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "c45dcc27331febabc20d86cb3974ef095257dcf3"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.0.4"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[WeakRefStrings]]
+deps = ["DataAPI", "Random", "Test"]
+git-tree-sha1 = "28807f85197eaad3cbd2330386fac1dcb9e7e11d"
+uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+version = "0.6.2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+BusinessDays = "4f18b42c-503e-5345-9536-bb0f25fc7038"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,0 @@
-DataFrames
-CSV

--- a/test/options.jl
+++ b/test/options.jl
@@ -10,100 +10,100 @@ d1 = today()
 bs = CSV.read("bs.csv")
 
 # 1. Test with floats
-calls = EuropeanCall.(d1 .+ Day.(bs[:days]), [s], float.(bs[:strikeprice]))
-puts = EuropeanPut.(d1 .+ Day.(bs[:days]), [s], float.(bs[:strikeprice]))
-m = GeomBMModel.([d1], float.(bs[:startprice]), bs[:interestrate], bs[:carryrate], bs[:sigma])
+calls = EuropeanCall.(d1 .+ Day.(bs.days), [s], float.(bs.strikeprice))
+puts = EuropeanPut.(d1 .+ Day.(bs.days), [s], float.(bs.strikeprice))
+m = GeomBMModel.([d1], float.(bs.startprice), bs.interestrate, bs.carryrate, bs.sigma)
 
 atol=1e-6; rtol=1e-3
 
-@test all(isapprox.(value.(m,calls), bs[:c], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,puts), bs[:p],  rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,calls), bs.c, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,puts), bs.p,  rtol=rtol,atol=atol))
 
-# @test all(isapprox.(ivol.(m,calls,value.(m,calls)), bs[:sigma]))
+# @test all(isapprox.(ivol.(m,calls,value.(m,calls)), bs.sigma))
 
 crr = CSV.read("crr.csv")
 
-eucalls = EuropeanCall.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice]))
-euputs  = EuropeanPut.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice] ))
-amcalls = AmericanCall.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice]))
-amputs  = AmericanPut.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice] ))
+eucalls = EuropeanCall.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice))
+euputs  = EuropeanPut.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice ))
+amcalls = AmericanCall.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice))
+amputs  = AmericanPut.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice ))
 
-m = CRRModel.(d1, d1 .+ Dates.Day.(crr[:days]), crr[:nsteps], float.(crr[:startprice]), crr[:interestrate], crr[:carryrate], crr[:sigma])
+m = CRRModel.(d1, d1 .+ Dates.Day.(crr.days), crr.nsteps, float.(crr.startprice), crr.interestrate, crr.carryrate, crr.sigma)
 
-@test all(isapprox.(value.(m,eucalls) , crr[:ce], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,euputs)  , crr[:pe], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amcalls) , crr[:ca], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amputs)  , crr[:pa], rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,eucalls) , crr.ce, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,euputs)  , crr.pe, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amcalls) , crr.ca, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amputs)  , crr.pa, rtol=rtol,atol=atol))
 
 tian = CSV.read("tian.csv")
 
-eucalls = EuropeanCall.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice]))
-euputs  = EuropeanPut.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice] ))
-amcalls = AmericanCall.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice]))
-amputs  = AmericanPut.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice] ))
+eucalls = EuropeanCall.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice))
+euputs  = EuropeanPut.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice ))
+amcalls = AmericanCall.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice))
+amputs  = AmericanPut.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice ))
 
-m = TianModel.([d1],d1 .+ Dates.Day.(tian[:days]), tian[:nsteps], float.(tian[:startprice]), tian[:interestrate], tian[:carryrate], tian[:sigma])
+m = TianModel.([d1],d1 .+ Dates.Day.(tian.days), tian.nsteps, float.(tian.startprice), tian.interestrate, tian.carryrate, tian.sigma)
 
-@test all(isapprox.(value.(m,eucalls) , tian[:ce], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,euputs)  , tian[:pe], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amcalls) , tian[:ca], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amputs)  , tian[:pa], rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,eucalls) , tian.ce, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,euputs)  , tian.pe, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amcalls) , tian.ca, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amputs)  , tian.pa, rtol=rtol,atol=atol))
 
 
 # 2. Test with currencies
-calls = EuropeanCall.(d1 .+ Day.(bs[:days]), [s], float.(bs[:strikeprice].*[USD]))
-puts = EuropeanPut.(d1 .+ Day.(bs[:days]), [s], float.(bs[:strikeprice].*[USD]))
-m = GeomBMModel.([d1], float.(bs[:startprice].*[USD]), bs[:interestrate], bs[:carryrate], bs[:sigma])
+calls = EuropeanCall.(d1 .+ Day.(bs.days), [s], float.(bs.strikeprice.*[USD]))
+puts = EuropeanPut.(d1 .+ Day.(bs.days), [s], float.(bs.strikeprice.*[USD]))
+m = GeomBMModel.([d1], float.(bs.startprice.*[USD]), bs.interestrate, bs.carryrate, bs.sigma)
 
 atol=1e-6; rtol=1e-3
 
-@test all(isapprox.(value.(m,calls) ./ [USD], bs[:c], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,puts) ./ [USD], bs[:p],  rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,calls) ./ [USD], bs.c, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,puts) ./ [USD], bs.p,  rtol=rtol,atol=atol))
 
 crr = CSV.read("crr.csv")
 
-eucalls = EuropeanCall.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice] .* [USD]))
-euputs  = EuropeanPut.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice] .* [USD]))
-amcalls = AmericanCall.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice] .* [USD]))
-amputs  = AmericanPut.(d1 .+ Dates.Day.(crr[:days]), [s], float.(crr[:strikeprice] .* [USD]))
+eucalls = EuropeanCall.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice .* [USD]))
+euputs  = EuropeanPut.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice .* [USD]))
+amcalls = AmericanCall.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice .* [USD]))
+amputs  = AmericanPut.(d1 .+ Dates.Day.(crr.days), [s], float.(crr.strikeprice .* [USD]))
 
 
-m = CRRModel.([d1],d1 .+ Dates.Day.(crr[:days]), crr[:nsteps], float.(crr[:startprice].*[USD]), crr[:interestrate], crr[:carryrate], crr[:sigma])
+m = CRRModel.([d1],d1 .+ Dates.Day.(crr.days), crr.nsteps, float.(crr.startprice.*[USD]), crr.interestrate, crr.carryrate, crr.sigma)
 
-@test all(isapprox.(value.(m,eucalls) ./ [USD], crr[:ce], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,euputs)  ./ [USD], crr[:pe], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amcalls) ./ [USD], crr[:ca], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amputs)  ./ [USD], crr[:pa], rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,eucalls) ./ [USD], crr.ce, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,euputs)  ./ [USD], crr.pe, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amcalls) ./ [USD], crr.ca, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amputs)  ./ [USD], crr.pa, rtol=rtol,atol=atol))
 
 tian = CSV.read("tian.csv")
 
-eucalls = EuropeanCall.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice] .* [USD]))
-euputs  = EuropeanPut.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice] .* [USD]))
-amcalls = AmericanCall.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice] .* [USD]))
-amputs  = AmericanPut.(d1 .+ Dates.Day.(tian[:days]), [s], float.(tian[:strikeprice] .* [USD]))
+eucalls = EuropeanCall.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice .* [USD]))
+euputs  = EuropeanPut.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice .* [USD]))
+amcalls = AmericanCall.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice .* [USD]))
+amputs  = AmericanPut.(d1 .+ Dates.Day.(tian.days), [s], float.(tian.strikeprice .* [USD]))
 
 
-m = TianModel.([d1],d1 .+ Dates.Day.(tian[:days]), tian[:nsteps], float.(tian[:startprice].*[USD]), tian[:interestrate], tian[:carryrate], tian[:sigma])
+m = TianModel.([d1],d1 .+ Dates.Day.(tian.days), tian.nsteps, float.(tian.startprice.*[USD]), tian.interestrate, tian.carryrate, tian.sigma)
 
-@test all(isapprox.(value.(m,eucalls) ./ [USD], tian[:ce], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,euputs)  ./ [USD], tian[:pe], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amcalls) ./ [USD], tian[:ca], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amputs)  ./ [USD], tian[:pa], rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,eucalls) ./ [USD], tian.ce, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,euputs)  ./ [USD], tian.pe, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amcalls) ./ [USD], tian.ca, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amputs)  ./ [USD], tian.pa, rtol=rtol,atol=atol))
 
 jr = CSV.read("jr.csv")
 
-eucalls = EuropeanCall.(d1 .+ Dates.Day.(jr[:days]), [s], float.(jr[:strikeprice] .* [USD]))
-euputs  = EuropeanPut.(d1 .+ Dates.Day.(jr[:days]), [s], float.(jr[:strikeprice] .* [USD]))
-amcalls = AmericanCall.(d1 .+ Dates.Day.(jr[:days]), [s], float.(jr[:strikeprice] .* [USD]))
-amputs  = AmericanPut.(d1 .+ Dates.Day.(jr[:days]), [s], float.(jr[:strikeprice] .* [USD]))
+eucalls = EuropeanCall.(d1 .+ Dates.Day.(jr.days), [s], float.(jr.strikeprice .* [USD]))
+euputs  = EuropeanPut.(d1 .+ Dates.Day.(jr.days), [s], float.(jr.strikeprice .* [USD]))
+amcalls = AmericanCall.(d1 .+ Dates.Day.(jr.days), [s], float.(jr.strikeprice .* [USD]))
+amputs  = AmericanPut.(d1 .+ Dates.Day.(jr.days), [s], float.(jr.strikeprice .* [USD]))
 
 
-m = JRModel.([d1],d1 .+ Dates.Day.(jr[:days]), jr[:nsteps], float.(jr[:startprice].*[USD]), jr[:interestrate], jr[:carryrate], jr[:sigma])
+m = JRModel.([d1],d1 .+ Dates.Day.(jr.days), jr.nsteps, float.(jr.startprice.*[USD]), jr.interestrate, jr.carryrate, jr.sigma)
 
-@test all(isapprox.(value.(m,eucalls) ./ [USD], jr[:ce], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,euputs)  ./ [USD], jr[:pe], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amcalls) ./ [USD], jr[:ca], rtol=rtol,atol=atol))
-@test all(isapprox.(value.(m,amputs)  ./ [USD], jr[:pa], rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,eucalls) ./ [USD], jr.ce, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,euputs)  ./ [USD], jr.pe, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amcalls) ./ [USD], jr.ca, rtol=rtol,atol=atol))
+@test all(isapprox.(value.(m,amputs)  ./ [USD], jr.pa, rtol=rtol,atol=atol))
 
 # Test Black-76 model
 d2 = d1 + Day(120)


### PR DESCRIPTION
Changes:

- Depreciation updates:
   - `AtObs` was depreciated but still used internally. Updated to `At`
   - In the tests, the `DataFrames` syntax of `df[:col]` was updated to `df.col` as the former gave a depreciation warning
- added `compat` entries in the primary `Project.toml`
- added `test/Project.toml` and removed `REQUIRES`
